### PR TITLE
Publish invalid messages to a validation errors topic

### DIFF
--- a/pubsub/protocol.py
+++ b/pubsub/protocol.py
@@ -1,6 +1,11 @@
 from pubsub.serializers.serializer import JSONSerializer
 from pubsub.validators.validator import ValidationError
 
+class ValidationErrorError(Exception):
+    def __init__(self, errors=None, *args, **kwargs):
+        self.errors = errors
+        super(ValidationErrorError, self).__init__(*args, **kwargs)
+
 
 class Protocol(object):
     """
@@ -20,7 +25,7 @@ class Protocol(object):
                 self.validator.validate_message(message)
             except ValidationError as exc:
                 if topic == 'validation_error':
-                    raise Exception('Validation error event is invalid: {}. Errors: {}'.format(message, ','.join(err.message for err in exc.errors)))
+                    raise ValidationErrorError('Validation error event is invalid: {}. Errors: {}'.format(message, ','.join(err.message for err in exc.errors)))
                 if self.validation_error_handler:
                     self.validation_error_handler(event=message, exception=exc, protocol=self)
                 raise

--- a/pubsub/protocol.py
+++ b/pubsub/protocol.py
@@ -19,12 +19,12 @@ class Protocol(object):
         self.validation_error_handler = validation_error_handler
         self.filter = filter
 
-    def publish(self, topic, message):
+    def publish(self, topic, message, validation_error_message=False):
         if self.validator:
             try:
                 self.validator.validate_message(message)
             except ValidationError as exc:
-                if topic == 'validation_error':
+                if validation_error_message:
                     raise ValidationErrorError('Validation error event is invalid: {}. Errors: {}'.format(message, ','.join(err.message for err in exc.errors)))
                 if self.validation_error_handler:
                     self.validation_error_handler(event=message, exception=exc, protocol=self)

--- a/pubsub/protocol.py
+++ b/pubsub/protocol.py
@@ -24,7 +24,7 @@ class Protocol(object):
                     self.publish(
                         self.validator.errors_topic,
                         dict(
-                            schema=self.validator.errors.schema,
+                            schema=self.validator.errors_schema,
                             event=message,
                             errors=[err.message for err in exc.errors]
                         )

--- a/pubsub/validators/validator.py
+++ b/pubsub/validators/validator.py
@@ -1,9 +1,34 @@
 import re
-import jsonschema
-from jsonschema import ValidationError
+
+from jsonschema import Draft4Validator, RefResolver
 
 
-class SchemaValidator():
+class ValidationError(Exception):
+    def __init__(self, *args, errors=None, **kwargs):
+        self.errors = errors
+        super(ValidationError, self).__init__(*args, **kwargs)
+
+
+class BaseValidator(object):
+    """
+    Validates pubsub messages against specified schema
+    """
+    publish_errors = False
+    errors_topic = None
+    errors_schema = None
+
+    def __init__(self, publish_errors=False, errors_topic=None, errors_schema=None):
+        self.publish_errors = publish_errors
+        if publish_errors and not errors_topic:
+            raise ValueError('errors_topic needs to be set if publish_errors is turned on')
+        if publish_errors and not errors_schema:
+            raise ValueError('errors_schema needs to be set if publish_errors is turned on')
+
+    def validate_message(self, message):
+        raise NotImplementedError()
+
+
+class SchemaValidator(BaseValidator):
     """
     Validates pubsub messages against specified schema
     """
@@ -17,17 +42,20 @@ class SchemaValidator():
             raise AttributeError('Message must be json')
         schema_uri = message.get('schema', '')
         matches = re.findall(r'(.+)://(.+/)?events/(.+)/(.+)/(.+)\.json', schema_uri)
-        if len(matches) >= 1:
-            schema = jsonschema.RefResolver('', '').resolve_remote(schema_uri)
-            jsonschema.validate(message, schema)
-        else:
+        if len(matches) < 1:
             raise ValidationError('Incorrect schema uri')
+        schema = RefResolver('', '').resolve_remote(schema_uri)
+        errors = []
+        for error in Draft4Validator(schema).iter_errors(message):
+            errors.append(error)
+        if errors:
+            raise ValidationError(errors=errors)
 
 
-class EmptyValidator():
+class EmptyValidator(BaseValidator):
     """
     Validates that message is not None
     """
 
     def validate_message(self, message):
-        return True if (message != '') else False
+        return message != ''

--- a/pubsub/validators/validator.py
+++ b/pubsub/validators/validator.py
@@ -1,10 +1,10 @@
 import re
 
-from jsonschema import Draft4Validator, RefResolver
+from jsonschema import Draft4Validator, RefResolver, ValidationError as SchemaValidationError
 
 
 class ValidationError(Exception):
-    def __init__(self, *args, errors=None, **kwargs):
+    def __init__(self, errors=None, *args, **kwargs):
         self.errors = errors
         super(ValidationError, self).__init__(*args, **kwargs)
 
@@ -13,17 +13,6 @@ class BaseValidator(object):
     """
     Validates pubsub messages against specified schema
     """
-    publish_errors = False
-    errors_topic = None
-    errors_schema = None
-
-    def __init__(self, publish_errors=False, errors_topic=None, errors_schema=None):
-        self.publish_errors = publish_errors
-        if publish_errors and not errors_topic:
-            raise ValueError('errors_topic needs to be set if publish_errors is turned on')
-        if publish_errors and not errors_schema:
-            raise ValueError('errors_schema needs to be set if publish_errors is turned on')
-
     def validate_message(self, message):
         raise NotImplementedError()
 
@@ -32,7 +21,6 @@ class SchemaValidator(BaseValidator):
     """
     Validates pubsub messages against specified schema
     """
-
     def validate_message(self, message):
         try:
             message.get('schema', None)
@@ -41,9 +29,9 @@ class SchemaValidator(BaseValidator):
         except AttributeError:
             raise AttributeError('Message must be json')
         schema_uri = message.get('schema', '')
-        matches = re.findall(r'(.+)://(.+/)?events/(.+)/(.+)/(.+)\.json', schema_uri)
+        matches = re.findall(r'(.+)://(.+/)?(.+)\.json', schema_uri)
         if len(matches) < 1:
-            raise ValidationError('Incorrect schema uri')
+            raise SchemaValidationError('Incorrect schema uri: {}'.format(schema_uri))
         schema = RefResolver('', '').resolve_remote(schema_uri)
         errors = []
         for error in Draft4Validator(schema).iter_errors(message):

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -118,9 +118,6 @@ class ProtocolTests(TestCase):
 class TestValidationErrorPublisher(TestCase):
     @classmethod
     def setUp(cls):
-        cls.schema = {
-            'required': ['foo']
-        }
         cls.valid_message = {
             'schema': 'http://json-schema.org/example/card.json',
             'familyName': 'foo',
@@ -134,7 +131,6 @@ class TestValidationErrorPublisher(TestCase):
             adapter=MockGoogleAdapter('test-client'),
             serializer=JSONSerializer(),
             validator=SchemaValidator())
-        cls.protocol.validator.schema = cls.schema
 
     def tearDown(self):
         self.protocol.adapter.clear_messages()

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -119,12 +119,12 @@ class TestValidationErrorPublisher(TestCase):
     @classmethod
     def setUp(cls):
         cls.valid_message = {
-            'schema': 'http://json-schema.org/example/card.json',
+            'schema': 'https://raw.githubusercontent.com/Superbalist/python-pubsub/gh-pages/examples/schema/card.json',
             'familyName': 'foo',
             'givenName': 'bar',
         }
         cls.invalid_message = {
-            'schema': 'http://json-schema.org/example/card.json',
+            'schema': 'https://raw.githubusercontent.com/Superbalist/python-pubsub/gh-pages/examples/schema/card.json',
             'givenName': 'baz',
         }
         cls.protocol = Protocol(
@@ -141,7 +141,7 @@ class TestValidationErrorPublisher(TestCase):
 
     def test_invalid_message(self):
         topic = 'validation_error'
-        schema = 'http://schema.superbalist.com/events/validation_error/validation_error/1.0.json'
+        schema = 'https://raw.githubusercontent.com/Superbalist/python-pubsub/gh-pages/examples/schema/validation-error.json'
 
         def validation_error_handler(event, exception, protocol):
             message = {
@@ -170,7 +170,7 @@ class TestValidationErrorPublisher(TestCase):
 
     def test_invalid_validation_error_message(self):
         topic = 'validation_error'
-        schema = 'http://schema.superbalist.com/events/validation_error/validation_error/1.0.json'
+        schema = 'https://raw.githubusercontent.com/Superbalist/python-pubsub/gh-pages/examples/schema/validation-error.json'
 
         def validation_error_handler(event, exception, protocol):
             message = {

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -158,7 +158,7 @@ class TestValidationErrorPublisher(TestCase):
                 'schema': schema
             }
             message.update(event=event, errors=[err.message for err in exception.errors])
-            protocol.publish(topic, message)
+            protocol.publish(topic, message, validation_error_message=True)
 
         self.protocol.validation_error_handler = validation_error_handler
 
@@ -184,15 +184,12 @@ class TestValidationErrorPublisher(TestCase):
                     'service': 'example-app',
                     'uuid': str(uuid4())
                 },
-                'schema': schema
+                'schema': schema,
+                'errors': [err.message for err in exception.errors]
             }
-            message.update(errors=[err.message for err in exception.errors])
-            protocol.publish(topic, message)
+            protocol.publish(topic, message, validation_error_message=True)
 
         self.protocol.validation_error_handler = validation_error_handler
-
-        def callback(message, data):
-            raise DoneException
 
         with self.assertRaises(ValidationErrorError):
             self.protocol.publish('python_test', self.invalid_message)

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,16 +1,19 @@
 # -*- coding: utf-8 -*-
 import threading
 from collections import defaultdict, deque
+from datetime import datetime
+from socket import gethostname
 from time import sleep
 from unittest import TestCase
+from uuid import uuid4
 
 from google.cloud.pubsub_v1 import futures
-from jsonschema import ValidationError
+from jsonschema import ValidationError as SchemaValidationError
 
 from pubsub.adapters.base import BaseAdapter
 from pubsub.protocol import Protocol
 from pubsub.serializers.serializer import JSONSerializer
-from pubsub.validators.validator import SchemaValidator
+from pubsub.validators.validator import SchemaValidator, ValidationError
 
 
 class MockGoogleAdapter(BaseAdapter):
@@ -20,6 +23,9 @@ class MockGoogleAdapter(BaseAdapter):
 
     def __init__(self, client_identifier):
         self.client_id = client_identifier
+        self._messages = defaultdict(deque)
+
+    def clear_messages(self):
         self._messages = defaultdict(deque)
 
     def publish(self, channel, message):
@@ -34,11 +40,12 @@ class MockGoogleAdapter(BaseAdapter):
 
         def create_message():
             sleep(0.1)
-            r = MockMessage(self._messages[channel].pop())
-            try:
-                return callback(r)
-            except Exception as exc:
-                future.set_exception(exc)
+            while self._messages[channel]:
+                r = MockMessage(self._messages[channel].pop())
+                try:
+                    return callback(r)
+                except Exception as exc:
+                    future.set_exception(exc)
 
         thread = threading.Thread(target=create_message)
         thread.start()
@@ -95,7 +102,7 @@ class ProtocolTests(TestCase):
             adapter=MockGoogleAdapter('test-client'),
             serializer=JSONSerializer(),
             validator=SchemaValidator())
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(SchemaValidationError):
             protocol.publish('python_test', self.invalid_message)
 
     # Only have one of these just to test its actually working
@@ -106,3 +113,61 @@ class ProtocolTests(TestCase):
     #     sub = protocol.subscribe('python_test')
     #     for message in sub:
     #         assert message == self.valid
+
+
+class TestValidationErrorPublisher(TestCase):
+    @classmethod
+    def setUp(cls):
+        cls.schema = {
+            'required': ['foo']
+        }
+        cls.valid_message = {
+            'schema': 'http://json-schema.org/example/card.json',
+            'familyName': 'foo',
+            'givenName': 'bar',
+        }
+        cls.invalid_message = {
+            'schema': 'http://json-schema.org/example/card.json',
+            'givenName': 'baz',
+        }
+        cls.protocol = Protocol(
+            adapter=MockGoogleAdapter('test-client'),
+            serializer=JSONSerializer(),
+            validator=SchemaValidator())
+        cls.protocol.validator.schema = cls.schema
+
+    def tearDown(self):
+        self.protocol.adapter.clear_messages()
+
+    def test_publish_error_defaults_to_false(self):
+        with self.assertRaises(ValidationError):
+            self.protocol.publish('python_test', self.invalid_message)
+
+    def test_invalid_message(self):
+        topic = 'validation_error'
+        schema = 'http://schema.superbalist.com/events/validation_error/validation_error/1.0.json'
+
+        def validation_error_handler(event, exception, protocol):
+            message = {
+                'meta': {
+                    'date': datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+                    'hostname': gethostname(),
+                    'service': 'example-app',
+                    'uuid': str(uuid4())
+                },
+                'schema': schema
+            }
+            message.update(event=event, errors=[err.message for err in exception.errors])
+            protocol.publish(topic, message)
+
+        self.protocol.validation_error_handler = validation_error_handler
+
+        def callback(message, data):
+            raise DoneException
+
+        with self.assertRaises(ValidationError):
+            self.protocol.publish('python_test', self.invalid_message)
+
+        future = self.protocol.subscribe('validation_error', callback=callback)
+        with self.assertRaises(DoneException):
+            future.result(timeout=1)


### PR DESCRIPTION
Adds `validation_error_callback` to `publish`:

e.g.:

```
        def validation_error_callback(event, exception, protocol):
            message = {
                'meta': {
                    'date': datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
                    'hostname': gethostname(),
                    'service': 'example-app',
                    'uuid': str(uuid4())
                },
                'schema': schema,
                'errors': [err.message for err in exception.errors]
            }
            protocol.publish(topic, message)
```