### PR TITLE
Update dependency name format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.1] - 2018-11-21
+- Update dependency naming
+
 ## [1.0.0] - 2018-11-21
 - [BREAKING] No longer supports python 2
 - Cache the results of get_topic
@@ -21,7 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.3.6] - 2015-12-03
 
-[Unreleased]: https://github.com/Superbalist/python-pubsub/compare/1.0.0...HEAD
+[Unreleased]: https://github.com/Superbalist/python-pubsub/compare/1.0.1...HEAD
+[1.0.1]: https://github.com/Superbalist/python-pubsub/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/Superbalist/python-pubsub/compare/0.3.9...1.0.0
 [0.3.9]: https://github.com/Superbalist/python-pubsub/compare/0.3.8...0.3.9
 [0.3.8]: https://github.com/Superbalist/python-pubsub/compare/0.3.7...0.3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-google.cloud.pubsub>=0.33.1
+google-cloud-pubsub>=0.33.1
 jsonschema
 requests

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    name='pubsub-py',
+    name='pubsub.py',
     author='Superbalist Engineering',
     author_email='tech@superbalist.com',
     version='1.0.1',

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,15 @@ from setuptools import setup, find_packages
 
 
 setup(
-    name='pubsub.py',
+    name='pubsub-py',
     author='Superbalist Engineering',
     author_email='tech@superbalist.com',
-    version='1.0.0',
+    version='1.0.1',
     description='Python PubSub Adapter for gcloud',
     long_description='Python PubSub Adapter for gcloud',
     url='https://github.com/Superbalist/python-pubsub',
     install_requires=[
-        'google.cloud.pubsub==0.33.1',
+        'google-cloud-pubsub==0.33.1',
         'jsonschema',
         'requests',
     ],


### PR DESCRIPTION
use`-` instead of `.` in package and dependency naming:

https://pypi.org/project/google-cloud-pubsub/

This was causing issues with some package management tools [pipenv,
poetry]

Still needs to be tested, to see if we can still install from pypi with the new "name"